### PR TITLE
Test on Node 4 instead of Node 0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "4"


### PR DESCRIPTION
Travis was failing before due to unpinned devDependency versions.